### PR TITLE
✨ Add search service and drivers

### DIFF
--- a/app/Actions/Content/DeleteContent.php
+++ b/app/Actions/Content/DeleteContent.php
@@ -5,23 +5,31 @@ namespace App\Actions\Content;
 use App\Models\Management\Space;
 use App\Models\Space\Content;
 use App\Models\User;
+use App\Services\Search\SearchService;
 use Illuminate\Contracts\Auth\Authenticatable;
 
 class DeleteContent
 {
+    public function __construct(
+        protected SearchService $searchService
+    ) {
+    }
+
     public function execute(Content $content, Space $space, Authenticatable|User|null $owner)
     {
         \DB::transaction(function () use ($content, $owner, $space) {
-            $this->deleteChildren($content);
+            $this->deleteChildren($content, $space);
+            $this->searchService->removeContent($content, $space);
             $content->delete();
             $space->touch('content_updated_at');
         });
     }
 
-    private function deleteChildren(Content $content)
+    private function deleteChildren(Content $content, Space $space)
     {
         foreach ($content->children as $child) {
-            $this->deleteChildren($child);
+            $this->deleteChildren($child, $space);
+            $this->searchService->removeContent($child, $space);
             $child->delete();
         }
     }

--- a/app/Actions/Content/PublishContent.php
+++ b/app/Actions/Content/PublishContent.php
@@ -6,10 +6,16 @@ use App\Models\Management\Space;
 use App\Models\Space\Content;
 use App\Models\Space\ContentVersion;
 use App\Models\User;
+use App\Services\Search\SearchService;
 use Illuminate\Contracts\Auth\Authenticatable;
 
 class PublishContent
 {
+    public function __construct(
+        protected SearchService $searchService
+    ) {
+    }
+
     public function execute(array $data, Content $content, Space $space, Authenticatable|User|null $owner)
     {
         \DB::transaction(function () use ($data, $content, $space, $owner) {
@@ -43,5 +49,8 @@ class PublishContent
 
             $space->touch('content_updated_at');
         });
+
+        $content->load('published_version');
+        $this->searchService->indexContent($content, $space);
     }
 }

--- a/app/Actions/Content/TransformContentToSearchable.php
+++ b/app/Actions/Content/TransformContentToSearchable.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Actions\Content;
+
+use App\Models\Space\Content;
+
+class TransformContentToSearchable
+{
+    public function execute(Content $content): string
+    {
+        $contentData = $content->getContent();
+
+        if (empty($contentData)) {
+            return '';
+        }
+
+        $textParts = [];
+
+        if ($content->name) {
+            $textParts[] = $content->name;
+        }
+
+        $this->extractTextFromStructure($contentData, $textParts);
+
+        return implode("\n", array_filter($textParts));
+    }
+
+    protected function extractTextFromStructure(array $data, array &$textParts): void
+    {
+        foreach ($data as $key => $value) {
+            if (\is_array($value)) {
+                $this->extractTextFromStructure($value, $textParts);
+            } elseif (\is_string($value) && !empty(trim($value))) {
+                if (!$this->isSystemField($key)) {
+                    $cleaned = $this->cleanText($value);
+                    if (!empty($cleaned)) {
+                        $textParts[] = $cleaned;
+                    }
+                }
+            }
+        }
+    }
+
+    protected function isSystemField(string $key): bool
+    {
+        $systemFields = ['id', 'uuid', 'type', 'component', 'plugin', '_uid'];
+
+        return \in_array($key, $systemFields) || \str_starts_with($key, '_');
+    }
+
+    protected function cleanText(string $text): string
+    {
+        $text = strip_tags($text);
+        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $text = preg_replace('/\s+/', ' ', $text);
+
+        return trim($text);
+    }
+}

--- a/app/Actions/Content/UnpublishContent.php
+++ b/app/Actions/Content/UnpublishContent.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Actions\Content;
+
+use App\Models\Management\Space;
+use App\Models\Space\Content;
+use App\Services\Search\SearchService;
+
+class UnpublishContent
+{
+    public function __construct(
+        protected SearchService $searchService
+    ) {
+    }
+
+    public function execute(Content $content, Space $space): void
+    {
+        \DB::transaction(function () use ($content, $space) {
+            $content->published_at = null;
+            $content->save();
+
+            $space->touch('content_updated_at');
+        });
+
+        $this->searchService->removeContent($content, $space);
+    }
+}

--- a/app/Actions/Content/UpdateContent.php
+++ b/app/Actions/Content/UpdateContent.php
@@ -6,12 +6,19 @@ use App\Models\Management\Space;
 use App\Models\Space\Content;
 use App\Models\Space\ContentVersion;
 use App\Models\User;
+use App\Services\Search\SearchService;
 use Illuminate\Contracts\Auth\Authenticatable;
 
 class UpdateContent
 {
+    public function __construct(
+        protected SearchService $searchService
+    ) {
+    }
     public function execute(array $data, Content $content, Space $space, Authenticatable|User|null $owner)
     {
+        $wasPublished = $content->published_at !== null;
+
         \DB::transaction(function () use ($data, $content, $space, $owner) {
             $contentData = data_get($data, 'content');
             $message = data_get($data, 'message');
@@ -36,5 +43,9 @@ class UpdateContent
 
             $space->touch('content_updated_at');
         });
+
+        if ($wasPublished && ($content->published_at === null)) {
+            $this->searchService->removeContent($content, $space);
+        }
     }
 }

--- a/app/Console/Commands/ReindexSpaceCommand.php
+++ b/app/Console/Commands/ReindexSpaceCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Management\Space;
+use App\Services\Database\ConnectionFactory;
+use App\Services\Search\SearchService;
+use Illuminate\Console\Command;
+
+class ReindexSpaceCommand extends Command
+{
+    protected $signature = 'search:reindex {space_id : The ID of the space to reindex}';
+
+    protected $description = 'Reindex all published content for a space in the search engine';
+
+    public function __construct(
+        protected SearchService $searchService
+    ) {
+        parent::__construct();
+    }
+
+    public function handle()
+    {
+        $spaceId = $this->argument('space_id');
+
+        $space = Space::find($spaceId);
+        app()->offsetSet('currentSpace', $space);
+
+        if (!$space) {
+            $this->error("Space with ID {$spaceId} not found.");
+            return 1;
+        }
+
+        $this->info("Starting reindexing for space: {$space->name} ({$space->id})");
+        $this->info("Search driver: {$space->getSearchDriver()->value}");
+
+        try {
+            $this->searchService->reindexSpace($space);
+            $this->info('Reindexing completed successfully.');
+            return 0;
+        } catch (\Exception $e) {
+            $this->error('Reindexing failed: ' . $e->getMessage());
+            return 1;
+        }
+    }
+}

--- a/app/Console/Commands/SwitchSearchDriverCommand.php
+++ b/app/Console/Commands/SwitchSearchDriverCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\SearchDriver;
+use App\Jobs\Space\ReindexSpaceJob;
+use App\Models\Management\Space;
+use App\Services\Search\SearchService;
+use Illuminate\Console\Command;
+
+class SwitchSearchDriverCommand extends Command
+{
+    protected $signature = 'search:driver {space_id : The ID of the space} {driver : The search driver (mysql or opensearch)}';
+
+    protected $description = 'Switch the search driver for a space and trigger reindexing';
+
+    public function __construct(
+        protected SearchService $searchService
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $spaceId = $this->argument('space_id');
+        $driverValue = $this->argument('driver');
+
+        $space = Space::find($spaceId);
+        app()->offsetSet('currentSpace', $space);
+
+        if (!$space) {
+            $this->error("Space with ID {$spaceId} not found.");
+            return 1;
+        }
+
+        try {
+            $newDriver = SearchDriver::from($driverValue);
+        } catch (\ValueError $e) {
+            $this->error("Invalid driver: {$driverValue}");
+            $this->info("Valid drivers: mysql, opensearch");
+            return 1;
+        }
+
+        $oldDriver = $space->getSearchDriver();
+
+        if ($oldDriver === $newDriver) {
+            $this->info("Space '{$space->name}' is already using the {$newDriver->value} driver.");
+            return 0;
+        }
+
+        $this->info("Switching search driver for space: {$space->name} ({$space->id})");
+        $this->info("Current driver: {$oldDriver->value}");
+        $this->info("New driver: {$newDriver->value}");
+
+        if (!$this->confirm('Do you want to continue?', true)) {
+            $this->info('Operation cancelled.');
+            return 0;
+        }
+
+        try {
+            $this->searchService->switchDriver($space, $newDriver);
+            $this->info("✓ Search driver switched successfully to {$newDriver->value}");
+
+            $this->info("Starting reindexing in background...");
+            ReindexSpaceJob::dispatch($space);
+            $this->info("✓ Reindexing job dispatched");
+
+            $this->newLine();
+            $this->info("Search driver switched successfully!");
+            $this->info("Reindexing is running in the background.");
+            $this->info("Monitor the queue worker logs for progress.");
+
+            return 0;
+        } catch (\Exception $e) {
+            $this->error("Failed to switch search driver: {$e->getMessage()}");
+            return 1;
+        }
+    }
+}

--- a/app/Contracts/Search/SearchDriverInterface.php
+++ b/app/Contracts/Search/SearchDriverInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Contracts\Search;
+
+use App\Models\Management\Space;
+use App\Models\Space\Content;
+
+interface SearchDriverInterface
+{
+    public function indexContent(Content $content, Space $space): void;
+
+    public function removeContent(Content $content, Space $space): void;
+
+    public function createIndex(Space $space): void;
+
+    public function deleteIndex(Space $space): void;
+
+    public function reindexSpace(Space $space): void;
+
+    public function search(Space $space, string $query, int $limit = 20, int $offset = 0): array;
+}

--- a/app/Enums/SearchDriver.php
+++ b/app/Enums/SearchDriver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enums;
+
+enum SearchDriver: string
+{
+    case MYSQL = 'mysql';
+    case OPENSEARCH = 'opensearch';
+
+    public function isOpenSearch(): bool
+    {
+        return $this === self::OPENSEARCH;
+    }
+
+    public function isMySql(): bool
+    {
+        return $this === self::MYSQL;
+    }
+}

--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\SearchResultResource;
+use App\Models\Management\Space;
+use App\Services\Search\SearchService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SearchController extends Controller
+{
+    public function __construct(
+        protected SearchService $searchService
+    ) {
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'q' => 'required|string|min:1|max:500',
+            'limit' => 'sometimes|integer|min:1|max:100',
+            'offset' => 'sometimes|integer|min:0',
+        ]);
+
+        $space = $request->route('space');
+
+        if (!$space instanceof Space) {
+            abort(404, 'Space not found');
+        }
+
+        $query = $validated['q'];
+        $limit = $validated['limit'] ?? 20;
+        $offset = $validated['offset'] ?? 0;
+
+        $results = $this->searchService->search($space, $query, $limit, $offset);
+
+        return response()->json([
+            'query' => $query,
+            'total' => $results['total'],
+            'limit' => $limit,
+            'offset' => $offset,
+            'results' => SearchResultResource::collection($results['results']),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Mgmt/Content/ContentPublishController.php
+++ b/app/Http/Controllers/Mgmt/Content/ContentPublishController.php
@@ -19,29 +19,10 @@ class ContentPublishController extends Controller
         $data = $request->validated();
         $action->execute($data, $content, $space, $request->user());
 
-//        if (!$content->save()) {
+        //        if (!$content->save()) {
 //            Log::error('Failed to publish content', ['content_id' => $content->id, 'space_id' => $space->id]);
 //            abort(500, 'Failed to publish content');
 //        }
-
-        $content->load(['block', 'parent', 'i18n_parent', 'i18n_children', 'i18n_siblings', 'current_version']);
-
-        return new ContentResource($content);
-    }
-
-    /**
-     * Unpublish the specified content item.
-     */
-    public function unpublish(Space $space, Content $content): ContentResource
-    {
-        $this->authorize('publish', [$content, $space]);
-
-        $content->published_at = null;
-        if (!$content->save()) {
-            Log::error('Failed to unpublish content', ['content_id' => $content->id, 'space_id' => $space->id]);
-            abort(500, 'Failed to unpublish content');
-        }
-        $space->touch('content_updated_at');
 
         $content->load(['block', 'parent', 'i18n_parent', 'i18n_children', 'i18n_siblings', 'current_version']);
 

--- a/app/Http/Controllers/Mgmt/Content/ContentUnpublishController.php
+++ b/app/Http/Controllers/Mgmt/Content/ContentUnpublishController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Mgmt\Content;
 
+use App\Actions\Content\UnpublishContent;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Management\ContentResource;
 use App\Models\Management\Space;
@@ -10,18 +11,14 @@ use Illuminate\Support\Facades\Log;
 
 class ContentUnpublishController extends Controller
 {
-
-    /**
-     * Unpublish the specified content item.
-     */
-    public function __invoke(Space $space, Content $content): ContentResource
+    public function __invoke(Space $space, Content $content, UnpublishContent $action): ContentResource
     {
         $this->authorize('publish', [$content, $space]);
 
-        $content->published_at = null;
-
-        if (!$content->save()) {
-            Log::error('Failed to unpublish content', ['content_id' => $content->id, 'space_id' => $space->id]);
+        try {
+            $action->execute($content, $space);
+        } catch (\Exception $e) {
+            Log::error('Failed to unpublish content', ['content_id' => $content->id, 'space_id' => $space->id, 'error' => $e->getMessage()]);
             abort(500, 'Failed to unpublish content');
         }
 

--- a/app/Http/Controllers/Mgmt/Content/ContentVersionPublishController.php
+++ b/app/Http/Controllers/Mgmt/Content/ContentVersionPublishController.php
@@ -8,11 +8,17 @@ use App\Http\Resources\Management\ContentVersionListResource;
 use App\Models\Management\Space;
 use App\Models\Space\Content;
 use App\Models\Space\ContentVersion;
+use App\Services\Search\SearchService;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 
 class ContentVersionPublishController extends Controller
 {
+    public function __construct(
+        protected SearchService $searchService
+    ) {
+    }
+
     public function __invoke(Space $space, Content $content, ContentVersion $version, Request $request)
     {
         $this->authorize('publish', [$content, $space]);
@@ -20,8 +26,13 @@ class ContentVersionPublishController extends Controller
         $content->published_version_id = $version->id;
         $content->published_at = now();
         $content->save();
-        $version->published_at = $version->published_at ?? now();
+        $version->published_at ??= now();
         $version->save();
+
+        $space->touch('content_updated_at');
+
+        $content->load('published_version');
+        $this->searchService->indexContent($content, $space);
 
         return response([])->setStatusCode(204);
     }

--- a/app/Http/Controllers/Mgmt/SpaceSearchController.php
+++ b/app/Http/Controllers/Mgmt/SpaceSearchController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Mgmt;
+
+use App\Enums\SearchDriver;
+use App\Http\Controllers\Controller;
+use App\Jobs\Space\ReindexSpaceJob;
+use App\Models\Management\Space;
+use App\Services\Search\SearchService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rules\Enum;
+
+class SpaceSearchController extends Controller
+{
+    public function __construct(
+        protected SearchService $searchService
+    ) {
+    }
+
+    public function update(Space $space, Request $request): JsonResponse
+    {
+        $this->authorize('update', $space);
+
+        $validated = $request->validate([
+            'search_driver' => ['required', new Enum(SearchDriver::class)]
+        ]);
+
+        $newDriver = SearchDriver::from($validated['search_driver']);
+
+        $this->searchService->switchDriver($space, $newDriver);
+
+        ReindexSpaceJob::dispatch($space);
+
+        return response()->json([
+            'message' => 'Search driver updated successfully. Reindexing in progress.',
+            'search_driver' => $newDriver->value
+        ]);
+    }
+
+    public function reindex(Space $space): JsonResponse
+    {
+        $this->authorize('update', $space);
+
+        ReindexSpaceJob::dispatch($space);
+
+        return response()->json([
+            'message' => 'Space reindexing started successfully.'
+        ]);
+    }
+}

--- a/app/Http/Middleware/AuthenticateDataApi.php
+++ b/app/Http/Middleware/AuthenticateDataApi.php
@@ -24,6 +24,7 @@ class AuthenticateDataApi
 
         $usageService = app(abstract: TokenUsageService::class);
         $token = $this->validateToken($plainTextToken, $usageService);
+        app()->offsetSet('currentSpace', $token->space);
         $request->route()->setParameter('space', $token->space);
 
         $execution = $usageService->startExecution($token, $start);

--- a/app/Http/Resources/Api/SearchResultResource.php
+++ b/app/Http/Resources/Api/SearchResultResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class SearchResultResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource['id'],
+            'name' => $this->resource['name'],
+            'slug' => $this->resource['slug'],
+            'full_slug' => $this->resource['full_slug'],
+            'language_iso' => $this->resource['language_iso'],
+            'block_id' => $this->resource['block_id'],
+            'published_at' => $this->resource['published_at'],
+            'relevance_score' => round($this->resource['relevance_score'], 4),
+        ];
+    }
+}

--- a/app/Jobs/Space/ReindexSpaceJob.php
+++ b/app/Jobs/Space/ReindexSpaceJob.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Jobs\Space;
+
+use App\Jobs\QueuedJob;
+use App\Models\Management\Space;
+use App\Services\Search\SearchService;
+use Illuminate\Support\Facades\Log;
+
+class ReindexSpaceJob extends QueuedJob
+{
+    public function __construct(
+        protected Space $space
+    ) {
+    }
+
+    protected function execute(): void
+    {
+        $searchService = app(SearchService::class);
+        $searchService->reindexSpace($this->space);
+    }
+
+    protected function handleFailure(\Exception $e): void
+    {
+        Log::error('Failed to reindex space', [
+            'space_id' => $this->space->id,
+            'error' => $e->getMessage(),
+            'trace' => $e->getTraceAsString()
+        ]);
+    }
+
+    protected function handleCompletion(): void
+    {
+        Log::info('Space reindexing completed', [
+            'space_id' => $this->space->id
+        ]);
+    }
+}

--- a/app/Models/Management/Space.php
+++ b/app/Models/Management/Space.php
@@ -3,6 +3,7 @@
 namespace App\Models\Management;
 
 use App\Casts\Slug;
+use App\Enums\SearchDriver;
 use App\Http\Resources\Management\SpaceResource;
 use App\Models\Traits\Auditable;
 use App\Models\Traits\HasPurifiedAttributes;
@@ -76,7 +77,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Space extends GlobalModel
 {
     use Auditable;
-//    use BroadcastsModelEvents;
+    //    use BroadcastsModelEvents;
     use HasFactory;
     use HasPurifiedAttributes;
     use HasUlids;
@@ -170,5 +171,12 @@ class Space extends GlobalModel
     public function getRvAttribute(): int
     {
         return $this->content_updated_at?->getTimestamp() ?? $this->updated_at?->getTimestamp() ?? 0;
+    }
+
+    public function getSearchDriver(): SearchDriver
+    {
+        $driverValue = data_get($this->settings, 'search_driver', SearchDriver::MYSQL->value);
+
+        return SearchDriver::from($driverValue);
     }
 }

--- a/app/Models/Space/Content.php
+++ b/app/Models/Space/Content.php
@@ -33,6 +33,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property \App\Models\Space\ContentSettings|null $settings
  * @property string $current_version_id
  * @property string|null $published_version_id
+ * @property string|null $searchable_content
  * @property \Illuminate\Support\Carbon|null $published_at
  * @property \Illuminate\Support\Carbon|null $first_published_at
  * @property \Illuminate\Support\Carbon|null $created_at
@@ -99,6 +100,7 @@ class Content extends SpaceModel
         'i18n_parent_id',
         'settings',
         'published_at',
+        'searchable_content',
     ];
 
     protected $casts = [
@@ -178,7 +180,7 @@ class Content extends SpaceModel
     {
         $result = ($this->relationLoaded('i18n_parent') ? $this->i18n_parent?->getContent() : []) ?? [];
 
-        return array_replace_recursive($result, json_decode($this->content ?? '[]', true));
+        return array_replace_recursive($result, $this->published_version->content ?? []);
     }
 
     public function setPublishedAt($date): void

--- a/app/Services/Database/SpaceModelResolver.php
+++ b/app/Services/Database/SpaceModelResolver.php
@@ -21,12 +21,12 @@ class SpaceModelResolver implements ConnectionResolverInterface
         }
 
         /** @var Space|null $space */
-        $space = request()->route('space');
-        abort_unless($space, 404, 'Space not found');
+        $space = app()->get('currentSpace');
+        abort_unless(!!$space, 404, 'Space not found');
 
         if (!isset($this->caches[$space->id])) {
             $connection = $space->defaultConnection[0] ?? null;
-            abort_unless($connection, 404, 'Connection not found');
+            abort_unless(!!$connection, 404, 'Connection not found');
             $this->caches[$space->id] = app(ConnectionFactory::class)->make($connection);
         }
 
@@ -35,7 +35,7 @@ class SpaceModelResolver implements ConnectionResolverInterface
 
     public function getConnectionName()
     {
-        return $this->getDefaultConnection()->getName();
+        return $this->getDefaultConnection()?->getName();
     }
 
     public function setDefaultConnection($name)

--- a/app/Services/Search/MySqlSearchDriver.php
+++ b/app/Services/Search/MySqlSearchDriver.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Services\Search;
+
+use App\Actions\Content\TransformContentToSearchable;
+use App\Contracts\Search\SearchDriverInterface;
+use App\Models\Management\Space;
+use App\Models\Space\Content;
+use Illuminate\Support\Facades\DB;
+
+class MySqlSearchDriver implements SearchDriverInterface
+{
+    public function __construct(
+        protected TransformContentToSearchable $transformer
+    ) {
+    }
+
+    public function indexContent(Content $content, Space $space): void
+    {
+        if (!$content->published_at) {
+            return;
+        }
+
+        $searchableText = $this->transformer->execute($content);
+        try {
+            $content->searchable_content = $searchableText;
+            $content->saveQuietly();
+        } catch (\Exception $e) {
+            if (str_contains($e->getMessage(), 'searchable_content')) {
+                return;
+            }
+            throw $e;
+        }
+    }
+
+    public function removeContent(Content $content, Space $space): void
+    {
+        try {
+            $content->searchable_content = null;
+            $content->saveQuietly();
+        } catch (\Exception $e) {
+            if (str_contains($e->getMessage(), 'searchable_content')) {
+                return;
+            }
+            throw $e;
+        }
+    }
+
+    public function createIndex(Space $space): void
+    {
+        $content = new Content();
+        $connection = $content->getConnection();
+        $tableName = $content->getTable();
+
+        $hasFullTextIndex = DB::connection($connection->getName())
+            ->select("SHOW INDEX FROM {$tableName} WHERE Index_type = 'FULLTEXT' AND Key_name = 'idx_searchable_content'");
+
+        if (empty($hasFullTextIndex)) {
+            DB::connection($connection->getName())
+                ->statement("ALTER TABLE {$tableName} ADD FULLTEXT INDEX idx_searchable_content (searchable_content)");
+        }
+    }
+
+    public function deleteIndex(Space $space): void
+    {
+        $content = new Content();
+        $connection = $content->getConnection();
+        $tableName = $content->getTable();
+
+        $hasFullTextIndex = DB::connection($connection->getName())
+            ->select("SHOW INDEX FROM {$tableName} WHERE Index_type = 'FULLTEXT' AND Key_name = 'idx_searchable_content'");
+
+        if (!empty($hasFullTextIndex)) {
+            DB::connection($connection->getName())
+                ->statement("ALTER TABLE {$tableName} DROP INDEX idx_searchable_content");
+        }
+    }
+
+    public function reindexSpace(Space $space): void
+    {
+        Content::whereNotNull('published_at')
+            ->with('published_version')
+            ->chunk(100, function ($contents) use ($space) {
+                foreach ($contents as $content) {
+                    $this->indexContent($content, $space);
+                }
+            });
+    }
+
+    public function search(Space $space, string $query, int $limit = 20, int $offset = 0): array
+    {
+        if (empty(trim($query))) {
+            return [
+                'total' => 0,
+                'results' => [],
+            ];
+        }
+
+        $content = new Content();
+        $connection = $content->getConnection();
+        $tableName = $content->getTable();
+
+        $searchQuery = $this->prepareSearchQuery($query);
+
+        try {
+            $totalQuery = Content::whereNotNull('published_at')
+                ->whereNotNull('searchable_content')
+                ->whereRaw("MATCH(searchable_content) AGAINST(? IN NATURAL LANGUAGE MODE)", [$searchQuery]);
+
+            $total = $totalQuery->count();
+
+            $results = Content::whereNotNull('published_at')
+                ->whereNotNull('searchable_content')
+                ->whereRaw("MATCH(searchable_content) AGAINST(? IN NATURAL LANGUAGE MODE)", [$searchQuery])
+                ->selectRaw("contents.*, MATCH(searchable_content) AGAINST(? IN NATURAL LANGUAGE MODE) as relevance_score", [$searchQuery])
+                ->orderByDesc('relevance_score')
+                ->skip($offset)
+                ->take($limit)
+                ->get()
+                ->map(function ($content) {
+                    return [
+                        'id' => $content->id,
+                        'name' => $content->name,
+                        'slug' => $content->slug,
+                        'full_slug' => $content->full_slug,
+                        'language_iso' => $content->language_iso,
+                        'block_id' => $content->block_id,
+                        'published_at' => $content->published_at?->toIso8601String(),
+                        'relevance_score' => $content->relevance_score,
+                    ];
+                })
+                ->toArray();
+
+            return [
+                'total' => $total,
+                'results' => $results,
+            ];
+        } catch (\Exception $e) {
+            if (str_contains($e->getMessage(), 'searchable_content')) {
+                return [
+                    'total' => 0,
+                    'results' => [],
+                ];
+            }
+            throw $e;
+        }
+    }
+
+    protected function prepareSearchQuery(string $query): string
+    {
+        return trim($query);
+    }
+}

--- a/app/Services/Search/OpenSearchDriver.php
+++ b/app/Services/Search/OpenSearchDriver.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace App\Services\Search;
+
+use App\Actions\Content\TransformContentToSearchable;
+use App\Contracts\Search\SearchDriverInterface;
+use App\Models\Management\Space;
+use App\Models\Space\Content;
+use GuzzleHttp\Client;
+use Illuminate\Support\Facades\Log;
+
+class OpenSearchDriver implements SearchDriverInterface
+{
+    protected Client $client;
+
+    public function __construct(
+        protected TransformContentToSearchable $transformer
+    ) {
+        $this->client = new Client([
+            'base_uri' => config('services.opensearch.host'),
+            'auth' => [
+                config('services.opensearch.username'),
+                config('services.opensearch.password')
+            ],
+            'verify' => config('services.opensearch.verify_ssl', true),
+            'timeout' => 30,
+        ]);
+    }
+
+    public function indexContent(Content $content, Space $space): void
+    {
+        if (!$content->published_at) {
+            return;
+        }
+
+        $searchableText = $this->transformer->execute($content);
+        $indexName = $this->getIndexName($space);
+
+        try {
+            $this->client->put("{$indexName}/_doc/{$content->id}", [
+                'json' => [
+                    'id' => $content->id,
+                    'name' => $content->name,
+                    'slug' => $content->slug,
+                    'full_slug' => $content->full_slug,
+                    'language_iso' => $content->language_iso,
+                    'block_id' => $content->block_id,
+                    'published_at' => $content->published_at?->toIso8601String(),
+                    'searchable_content' => $searchableText,
+                ]
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Failed to index content in OpenSearch', [
+                'content_id' => $content->id,
+                'space_id' => $space->id,
+                'error' => $e->getMessage()
+            ]);
+            throw $e;
+        }
+    }
+
+    public function removeContent(Content $content, Space $space): void
+    {
+        $indexName = $this->getIndexName($space);
+
+        try {
+            $this->client->delete("{$indexName}/_doc/{$content->id}");
+        } catch (\Exception $e) {
+            if (!str_contains($e->getMessage(), '404')) {
+                Log::error('Failed to remove content from OpenSearch', [
+                    'content_id' => $content->id,
+                    'space_id' => $space->id,
+                    'error' => $e->getMessage()
+                ]);
+                throw $e;
+            }
+        }
+    }
+
+    public function createIndex(Space $space): void
+    {
+        $indexName = $this->getIndexName($space);
+
+        try {
+            $this->client->get($indexName);
+            return;
+        } catch (\Exception $e) {
+            if (!str_contains($e->getMessage(), '404')) {
+                throw $e;
+            }
+        }
+
+        try {
+            $this->client->put($indexName, [
+                'json' => [
+                    'settings' => [
+                        'number_of_shards' => 1,
+                        'number_of_replicas' => 1,
+                        'analysis' => [
+                            'analyzer' => [
+                                'default' => [
+                                    'type' => 'standard'
+                                ]
+                            ]
+                        ]
+                    ],
+                    'mappings' => [
+                        'properties' => [
+                            'id' => ['type' => 'keyword'],
+                            'name' => ['type' => 'text'],
+                            'slug' => ['type' => 'keyword'],
+                            'full_slug' => ['type' => 'keyword'],
+                            'language_iso' => ['type' => 'keyword'],
+                            'block_id' => ['type' => 'keyword'],
+                            'published_at' => ['type' => 'date'],
+                            'searchable_content' => [
+                                'type' => 'text',
+                                'analyzer' => 'standard'
+                            ]
+                        ]
+                    ]
+                ]
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Failed to create OpenSearch index', [
+                'space_id' => $space->id,
+                'index_name' => $indexName,
+                'error' => $e->getMessage()
+            ]);
+            throw $e;
+        }
+    }
+
+    public function deleteIndex(Space $space): void
+    {
+        $indexName = $this->getIndexName($space);
+
+        try {
+            $this->client->delete($indexName);
+        } catch (\Exception $e) {
+            if (!str_contains($e->getMessage(), '404')) {
+                Log::error('Failed to delete OpenSearch index', [
+                    'space_id' => $space->id,
+                    'index_name' => $indexName,
+                    'error' => $e->getMessage()
+                ]);
+                throw $e;
+            }
+        }
+    }
+
+    public function reindexSpace(Space $space): void
+    {
+        $this->createIndex($space);
+
+        Content::whereNotNull('published_at')
+            ->with('published_version')
+            ->chunk(100, function ($contents) use ($space) {
+                foreach ($contents as $content) {
+                    $this->indexContent($content, $space);
+                }
+            });
+    }
+
+    protected function getIndexName(Space $space): string
+    {
+        return "space_{$space->id}";
+    }
+
+    public function search(Space $space, string $query, int $limit = 20, int $offset = 0): array
+    {
+        if (empty(trim($query))) {
+            return [
+                'total' => 0,
+                'results' => [],
+            ];
+        }
+
+        $indexName = $this->getIndexName($space);
+
+        try {
+            $response = $this->client->post("{$indexName}/_search", [
+                'json' => [
+                    'from' => $offset,
+                    'size' => $limit,
+                    'query' => [
+                        'match' => [
+                            'searchable_content' => [
+                                'query' => $query,
+                                'operator' => 'or'
+                            ]
+                        ]
+                    ],
+                    'sort' => [
+                        '_score' => ['order' => 'desc']
+                    ]
+                ]
+            ]);
+
+            $body = json_decode($response->getBody()->getContents(), true);
+            $hits = $body['hits'] ?? [];
+            $total = $hits['total']['value'] ?? 0;
+
+            $results = array_map(function ($hit) {
+                $source = $hit['_source'];
+                return [
+                    'id' => $source['id'],
+                    'name' => $source['name'],
+                    'slug' => $source['slug'],
+                    'full_slug' => $source['full_slug'],
+                    'language_iso' => $source['language_iso'],
+                    'block_id' => $source['block_id'],
+                    'published_at' => $source['published_at'],
+                    'relevance_score' => $hit['_score'],
+                ];
+            }, $hits['hits'] ?? []);
+
+            return [
+                'total' => $total,
+                'results' => $results,
+            ];
+        } catch (\Exception $e) {
+            if (str_contains($e->getMessage(), '404')) {
+                return [
+                    'total' => 0,
+                    'results' => [],
+                ];
+            }
+
+            Log::error('Failed to search content in OpenSearch', [
+                'space_id' => $space->id,
+                'query' => $query,
+                'error' => $e->getMessage()
+            ]);
+            throw $e;
+        }
+    }
+}

--- a/app/Services/Search/SearchService.php
+++ b/app/Services/Search/SearchService.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Services\Search;
+
+use App\Contracts\Search\SearchDriverInterface;
+use App\Enums\SearchDriver;
+use App\Models\Management\Space;
+use App\Models\Space\Content;
+use InvalidArgumentException;
+
+class SearchService
+{
+    protected array $drivers = [];
+
+    public function __construct(
+        protected MySqlSearchDriver $mySqlDriver,
+        protected OpenSearchDriver $openSearchDriver
+    ) {
+        $this->drivers[SearchDriver::MYSQL->value] = $this->mySqlDriver;
+        $this->drivers[SearchDriver::OPENSEARCH->value] = $this->openSearchDriver;
+    }
+
+    public function getDriver(Space $space): SearchDriverInterface
+    {
+        $driverType = $this->getSearchDriver($space);
+
+        if (!isset($this->drivers[$driverType->value])) {
+            throw new InvalidArgumentException("Search driver [{$driverType->value}] is not supported.");
+        }
+
+        return $this->drivers[$driverType->value];
+    }
+
+    public function indexContent(Content $content, Space $space): void
+    {
+        $driver = $this->getDriver($space);
+        $driver->indexContent($content, $space);
+    }
+
+    public function removeContent(Content $content, Space $space): void
+    {
+        $driver = $this->getDriver($space);
+        $driver->removeContent($content, $space);
+    }
+
+    public function switchDriver(Space $space, SearchDriver $newDriver): void
+    {
+        $oldDriver = $this->getSearchDriver($space);
+        if ($oldDriver === $newDriver) {
+            return;
+        }
+
+        if ($oldDriver->isOpenSearch()) {
+            $this->drivers[$oldDriver->value]->deleteIndex($space);
+        }
+
+        $space->settings = ($space->settings ?? []) + [
+            'search_driver' => $newDriver->value
+        ];
+        $space->save();
+
+        if ($newDriver->isOpenSearch()) {
+            $this->drivers[$newDriver->value]->createIndex($space);
+        }
+    }
+
+    public function reindexSpace(Space $space): void
+    {
+        app()->offsetSet('currentSpace', $space);
+        $driver = $this->getDriver($space);
+        $driver->reindexSpace($space);
+    }
+
+    public function search(Space $space, string $query, int $limit = 20, int $offset = 0): array
+    {
+        $driver = $this->getDriver($space);
+        return $driver->search($space, $query, $limit, $offset);
+    }
+
+    protected function getSearchDriver(Space $space): SearchDriver
+    {
+        return $space->getSearchDriver();
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -64,4 +64,11 @@ return [
             'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),
         ],
     ],
+
+    'opensearch' => [
+        'host' => env('OPENSEARCH_HOST', 'http://localhost:9200'),
+        'username' => env('OPENSEARCH_USERNAME'),
+        'password' => env('OPENSEARCH_PASSWORD'),
+        'verify_ssl' => env('OPENSEARCH_VERIFY_SSL', true),
+    ],
 ];

--- a/database/migrations/spaces/0000_00_00_000004_create_space_tables.php
+++ b/database/migrations/spaces/0000_00_00_000004_create_space_tables.php
@@ -147,10 +147,13 @@ return new class extends Migration {
             $table->foreignUlid('current_version_id');
             $table->foreignUlid('published_version_id')->nullable();
 
+            $table->longText('searchable_content')->nullable();
+
             $table->timestamp('published_at')->nullable();
             $table->timestamp('first_published_at')->nullable();
 
             $table->index(['full_slug']);
+            $table->fullText('searchable_content');
             $table->timestamps();
             $table->softDeletes();
         });

--- a/routes/data_api.php
+++ b/routes/data_api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\BlockController;
 use App\Http\Controllers\Api\ContentController;
+use App\Http\Controllers\Api\SearchController;
 use App\Http\Controllers\Api\DataEntryController;
 use App\Http\Controllers\Api\DataSourceController;
 use App\Http\Controllers\Api\RedirectController;
@@ -11,6 +12,8 @@ use App\Http\Controllers\Api\SpaceController;
 Route::get('contents', [ContentController::class, 'index'])
     ->middleware('revision')
     ->name('contents.index');
+Route::get('search', SearchController::class)
+    ->name('contents.search');
 Route::get('contents/{slug}', [ContentController::class, 'show'])
     ->middleware('revision')
     ->where('slug', '.*')

--- a/routes/private_mgmt.php
+++ b/routes/private_mgmt.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\Mgmt\RedirectResetController;
 use App\Http\Controllers\Mgmt\SpaceArchiveController;
 use App\Http\Controllers\Mgmt\SpaceController;
 use App\Http\Controllers\Mgmt\SpaceIconController;
+use App\Http\Controllers\Mgmt\SpaceSearchController;
 use App\Http\Controllers\Mgmt\SpaceStatsController;
 use App\Http\Controllers\Mgmt\SpaceTokenController;
 use App\Http\Controllers\Mgmt\TeamController;
@@ -69,6 +70,9 @@ Route::group(['prefix' => 'spaces/{space}'], function () {
     Route::post('icon', SpaceIconController::class)->name('spaces.icon');
     Route::post('archive', SpaceArchiveController::class)->name('spaces.archive');
     Route::get('ai-usage', SpaceAiUsageController::class)->name('spaces.ai-usage');
+
+    Route::patch('search', [SpaceSearchController::class, 'update'])->name('spaces.search.update');
+    Route::post('search/reindex', [SpaceSearchController::class, 'reindex'])->name('spaces.search.reindex');
 
     Route::apiResource('blocks', BlockController::class);
     Route::apiResource('block-tags', BlockTagController::class)->parameters([


### PR DESCRIPTION
Introduce a search subsystem: SearchService, drivers (MySQL and OpenSearch),
SearchDriver enum and SearchDriverInterface, and a transformer to convert
content into searchable text. Integrate indexing/removal into content actions, add API and management controllers, console commands, and a ReindexSpace job. Add SearchResult resource, middleware to set currentSpace,
and a migration/column for searchable_content.