### PR TITLE
Revisit published content and release scheduling

### DIFF
--- a/app/Actions/Content/SchedulePublishContent.php
+++ b/app/Actions/Content/SchedulePublishContent.php
@@ -2,13 +2,12 @@
 
 namespace App\Actions\Content;
 
+use App\Jobs\Content\PublishScheduledContentJob;
 use App\Models\Management\Space;
 use App\Models\Space\Content;
-use App\Models\Space\ContentVersion;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Contracts\Auth\Authenticatable;
-use Illuminate\Support\Facades\Log;
 
 class SchedulePublishContent extends BasePublishAction
 {
@@ -17,16 +16,15 @@ class SchedulePublishContent extends BasePublishAction
         $content = $this->lockContentForUpdate($content);
 
         \DB::transaction(function () use ($data, $content, $space, $owner) {
-            $this->processSchedule($data, $content, $owner);
+            $this->processSchedule($data, $content, $owner, $space);
             $content->save();
         });
     }
 
-    private function processSchedule(array $data, Content $content, Authenticatable|User|null $owner): void
+    private function processSchedule(array $data, Content $content, Authenticatable|User|null $owner, Space $space): void
     {
         $scheduledAt = Carbon::parse(data_get($data, 'scheduled_at'));
         ['contentData' => $contentData, 'message' => $message] = $this->extractDataFromRequest($data);
-
 
         $this->clearScheduledVersions($content);
         $this->updateContent($data, $content);
@@ -40,6 +38,13 @@ class SchedulePublishContent extends BasePublishAction
         } else {
             $version = $this->createNewVersion($values, $contentData, $content, $owner);
             $content->current_version_id = $version->id;
+        }
+
+        if ($scheduledAt?->isFuture()) {
+            PublishScheduledContentJob::dispatch(
+                $space->id,
+                $content->current_version_id,
+            )->delay($scheduledAt);
         }
     }
 }

--- a/app/Actions/Release/CommitRelease.php
+++ b/app/Actions/Release/CommitRelease.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Actions\Release;
+
+use App\Jobs\Release\PublishScheduledReleaseJob;
+use App\Models\Management\Space;
+use App\Models\Space\Release;
+
+class CommitRelease
+{
+    public function execute(Release $release, Space $space): void
+    {
+        if ($release->publish_at === null) {
+            return;
+        }
+
+        PublishScheduledReleaseJob::dispatch(
+            $space->id,
+            $release->id,
+        )->delay($release->publish_at);
+    }
+}

--- a/app/Console/Commands/PublishScheduledReleases.php
+++ b/app/Console/Commands/PublishScheduledReleases.php
@@ -105,7 +105,7 @@ class PublishScheduledReleases extends Command
         try {
             Release::where('published_at', null)
                 ->where('publish_at', '<=', now())
-                ->where('committed_at', null)
+                ->whereNotNull('committed_at')
                 ->lazy(200)
                 ->each(function ($release) use ($space, &$published, &$failed) {
                     try {

--- a/app/Console/Commands/RequeueOrphanedPublishingJobs.php
+++ b/app/Console/Commands/RequeueOrphanedPublishingJobs.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\Content\PublishScheduledContentJob;
+use App\Jobs\Release\PublishScheduledReleaseJob;
+use App\Models\Management\Space;
+use App\Models\Space\ContentVersion;
+use App\Models\Space\Release;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class RequeueOrphanedPublishingJobs extends Command
+{
+    protected $signature = 'queue:requeue-orphaned-publishing {--dry-run : Display orphaned items without requeueing}';
+
+    protected $description = 'Find and requeue orphaned scheduled content and releases that may have been missed by the queue system';
+
+    public function handle(): int
+    {
+        $dryRun = $this->option('dry-run');
+        $startTime = microtime(true);
+
+        $contentVersions = $this->findOrphanedContentVersions();
+        $releases = $this->findOrphanedReleases();
+
+        $totalOrphaned = \count($contentVersions) + \count($releases);
+
+        if ($totalOrphaned === 0) {
+            $this->info('No orphaned publishing jobs found.');
+            return 0;
+        }
+
+        $this->warn("Found {$totalOrphaned} orphaned publishing job(s).");
+
+        if ($dryRun) {
+            $this->displayOrphanedItems($contentVersions, $releases);
+            return 0;
+        }
+
+        $requeued = $this->requeueItems($contentVersions, $releases);
+
+        $duration = microtime(true) - $startTime;
+
+        $this->info("========================================");
+        $this->info("Orphaned Jobs Requeue Summary");
+        $this->info("========================================");
+        $this->info("Total requeued: {$requeued}");
+        $this->info("Duration: {$duration}s");
+
+        Log::info('Orphaned publishing jobs requeued', [
+            'total_requeued' => $requeued,
+            'duration_seconds' => $duration,
+        ]);
+
+        return 0;
+    }
+
+    /**
+     * Find content versions scheduled for publishing that aren't queued or already published
+     *
+     * @return array<int, array{space_id: string, version_id: string, space_name: string, scheduled_at: string}>
+     */
+    protected function findOrphanedContentVersions(): array
+    {
+        $orphaned = [];
+
+        foreach (Space::query()->get() as $space) {
+            app()->offsetSet('currentSpace', $space);
+
+            $versions = ContentVersion::query()
+                ->where('scheduled_at', '<=', now()->subMinutes(30))
+                ->whereNull('published_at')
+                ->select('id', 'scheduled_at')
+                ->lazy()
+                ->map(fn($version) => [
+                    'space_id' => $space->id,
+                    'space_name' => $space->name,
+                    'version_id' => $version->id,
+                    'scheduled_at' => $version->scheduled_at?->toDateTimeString(),
+                ])->toArray();
+
+            $orphaned = \array_merge($orphaned, $versions);
+        }
+
+        return $orphaned;
+    }
+
+    /**
+     * Find releases scheduled for publishing that aren't queued or already published
+     *
+     * @return array<int, array{space_id: string, release_id: string, space_name: string, publish_at: string}>
+     */
+    protected function findOrphanedReleases(): array
+    {
+        $orphaned = [];
+
+        foreach (Space::query()->get() as $space) {
+            app()->offsetSet('currentSpace', $space);
+
+            $releases = Release::query()
+                ->where('publish_at', '<=', now()->subMinutes(30))
+                ->whereNull('published_at')
+                ->whereNotNull('committed_at')
+                ->select('id', 'publish_at')
+                ->lazy()
+                ->map(
+                    fn($release) => [
+                        'space_id' => $space->id,
+                        'space_name' => $space->name,
+                        'release_id' => $release->id,
+                        'publish_at' => $release->publish_at?->toDateTimeString(),
+                    ]
+                )->toArray();
+
+            $orphaned = \array_merge($orphaned, $releases);
+        }
+
+        return $orphaned;
+    }
+
+    /**
+     * Display orphaned items for inspection
+     *
+     * @param array<int, array{space_id: string, version_id: string, space_name: string, scheduled_at: string}> $contentVersions
+     * @param array<int, array{space_id: string, release_id: string, space_name: string, publish_at: string}> $releases
+     */
+    protected function displayOrphanedItems(array $contentVersions, array $releases): void
+    {
+        if (!empty($contentVersions)) {
+            $this->line("\n<info>Orphaned Content Versions:</info>");
+            foreach ($contentVersions as $item) {
+                $this->line("  - Space: {$item['space_name']} ({$item['space_id']}), Version: {$item['version_id']}, Scheduled: {$item['scheduled_at']}");
+            }
+        }
+
+        if (!empty($releases)) {
+            $this->line("\n<info>Orphaned Releases:</info>");
+            foreach ($releases as $item) {
+                $this->line("  - Space: {$item['space_name']} ({$item['space_id']}), Release: {$item['release_id']}, Publish At: {$item['publish_at']}");
+            }
+        }
+    }
+
+    /**
+     * Requeue orphaned items
+     *
+     * @param array<int, array{space_id: string, version_id: string, space_name: string, scheduled_at: string}> $contentVersions
+     * @param array<int, array{space_id: string, release_id: string, space_name: string, publish_at: string}> $releases
+     */
+    protected function requeueItems(array $contentVersions, array $releases): int
+    {
+        $requeued = 0;
+
+        foreach ($contentVersions as $item) {
+            try {
+                PublishScheduledContentJob::dispatch(
+                    $item['space_id'],
+                    $item['version_id'],
+                );
+                $this->info("Requeued content version {$item['version_id']} from space {$item['space_name']}");
+                $requeued++;
+            } catch (\Exception $e) {
+                $this->error("Failed to requeue content version {$item['version_id']}: {$e->getMessage()}");
+                Log::error('Failed to requeue orphaned content version', [
+                    'space_id' => $item['space_id'],
+                    'version_id' => $item['version_id'],
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        foreach ($releases as $item) {
+            try {
+                PublishScheduledReleaseJob::dispatch(
+                    $item['space_id'],
+                    $item['release_id'],
+                );
+                $this->info("Requeued release {$item['release_id']} from space {$item['space_name']}");
+                $requeued++;
+            } catch (\Exception $e) {
+                $this->error("Failed to requeue release {$item['release_id']}: {$e->getMessage()}");
+                Log::error('Failed to requeue orphaned release', [
+                    'space_id' => $item['space_id'],
+                    'release_id' => $item['release_id'],
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return $requeued;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -19,13 +19,9 @@ class Kernel extends ConsoleKernel
             ->onOneServer()
             ->withoutOverlapping()
             ->runInBackground();
-        $schedule->command('content:publish-scheduled')
-            ->everyMinute()
-            ->onOneServer()
-            ->withoutOverlapping()
-            ->runInBackground();
-        $schedule->command('releases:publish-scheduled')
-            ->everyMinute()
+
+        $schedule->command('queue:requeue-orphaned-publishing')
+            ->dailyAt('01:00')
             ->onOneServer()
             ->withoutOverlapping()
             ->runInBackground();

--- a/app/Http/Controllers/Mgmt/Release/ReleaseCommitController.php
+++ b/app/Http/Controllers/Mgmt/Release/ReleaseCommitController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Mgmt\Release;
 
+use App\Actions\Release\CommitRelease;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Management\ReleaseResource;
 use App\Models\Management\Space;
@@ -11,7 +12,7 @@ use Illuminate\Support\Facades\Log;
 
 class ReleaseCommitController extends Controller
 {
-    public function __invoke(Space $space, Release $release): ReleaseResource
+    public function __invoke(Space $space, Release $release, CommitRelease $action): ReleaseResource
     {
         $this->authorize('commit', [$release, $space]);
 
@@ -19,6 +20,7 @@ class ReleaseCommitController extends Controller
             $release->committed_at = now();
             $release->save();
             $release->loadCount(['versions']);
+            $action->execute($release, $space);
 
             return new ReleaseResource($release);
         } catch (\Exception $e) {

--- a/app/Jobs/Content/PublishScheduledContentJob.php
+++ b/app/Jobs/Content/PublishScheduledContentJob.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Jobs\Content;
+
+use App\Actions\Content\PublishScheduledContent;
+use App\Jobs\QueuedJob;
+use App\Models\Management\Space;
+use App\Models\Space\ContentVersion;
+use Illuminate\Support\Facades\Log;
+
+class PublishScheduledContentJob extends QueuedJob
+{
+    public int $timeout = 300;
+
+    public function __construct(
+        protected string $spaceId,
+        protected string $contentVersionId,
+    ) {
+        $this->onConnection('database');
+    }
+
+    protected function execute(): void
+    {
+        $space = Space::find($this->spaceId);
+        if (!$space) {
+            Log::warning('Space not found for scheduled content job', [
+                'space_id' => $this->spaceId,
+            ]);
+            return;
+        }
+
+        app()->offsetSet('currentSpace', $space);
+
+        $version = ContentVersion::find($this->contentVersionId);
+        if (!$version) {
+            Log::warning('Content version not found for scheduled content job', [
+                'content_version_id' => $this->contentVersionId,
+                'space_id' => $this->spaceId,
+            ]);
+            return;
+        }
+
+        if ($version->published_at !== null) {
+            Log::info('Content version already published, skipping', [
+                'content_version_id' => $this->contentVersionId,
+                'space_id' => $this->spaceId,
+            ]);
+            return;
+        }
+
+        if ($version->scheduled_at === null || $version->scheduled_at->isFuture()) {
+            Log::info('Content version schedule time not yet met or invalid, requeueing', [
+                'content_version_id' => $this->contentVersionId,
+                'space_id' => $this->spaceId,
+                'scheduled_at' => $version->scheduled_at,
+            ]);
+
+            if ($version->scheduled_at?->isFuture()) {
+                PublishScheduledContentJob::dispatch(
+                    $this->spaceId,
+                    $this->contentVersionId,
+                )->delay($version->scheduled_at);
+            }
+
+            return;
+        }
+
+        $content = $version->contentModel;
+        if (!$content) {
+            Log::warning('Content model not found for version', [
+                'content_version_id' => $this->contentVersionId,
+                'space_id' => $this->spaceId,
+            ]);
+            return;
+        }
+
+        $publishAction = app(PublishScheduledContent::class);
+        $publishAction->execute($version, $content, $space, null);
+
+        Log::info('Published scheduled content version', [
+            'content_version_id' => $this->contentVersionId,
+            'content_id' => $content->id,
+            'space_id' => $this->spaceId,
+        ]);
+    }
+
+    protected function handleFailure(\Exception $e): void
+    {
+        Log::error('Failed to publish scheduled content version', [
+            'content_version_id' => $this->contentVersionId,
+            'space_id' => $this->spaceId,
+            'error' => $e->getMessage(),
+            'trace' => $e->getTraceAsString(),
+        ]);
+    }
+
+    public function tags(): array
+    {
+        return [
+            'content-publishing',
+            'space:' . $this->spaceId,
+            'content-version:' . $this->contentVersionId,
+        ];
+    }
+}

--- a/app/Jobs/Release/PublishScheduledReleaseJob.php
+++ b/app/Jobs/Release/PublishScheduledReleaseJob.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Jobs\Release;
+
+use App\Actions\Release\PublishRelease;
+use App\Jobs\QueuedJob;
+use App\Models\Management\Space;
+use App\Models\Space\Release;
+use Illuminate\Support\Facades\Log;
+
+class PublishScheduledReleaseJob extends QueuedJob
+{
+    public int $timeout = 300;
+
+    public function __construct(
+        protected string $spaceId,
+        protected string $releaseId,
+    ) {
+        $this->onConnection('database');
+    }
+
+    protected function execute(): void
+    {
+        $space = Space::find($this->spaceId);
+        if (!$space) {
+            Log::warning('Space not found for scheduled release job', [
+                'space_id' => $this->spaceId,
+            ]);
+            return;
+        }
+
+        app()->offsetSet('currentSpace', $space);
+
+        $release = Release::find($this->releaseId);
+        if (!$release) {
+            Log::warning('Release not found for scheduled release job', [
+                'release_id' => $this->releaseId,
+                'space_id' => $this->spaceId,
+            ]);
+            return;
+        }
+
+        if ($release->published_at !== null) {
+            Log::info('Release already published, skipping', [
+                'release_id' => $this->releaseId,
+                'space_id' => $this->spaceId,
+            ]);
+            return;
+        }
+
+        if ($release->committed_at === null) {
+            Log::info('Release not yet committed, skipping', [
+                'release_id' => $this->releaseId,
+                'space_id' => $this->spaceId,
+            ]);
+            return;
+        }
+
+        if ($release->publish_at === null || $release->publish_at->isFuture()) {
+            Log::info('Release publish time not yet met or invalid, requeueing', [
+                'release_id' => $this->releaseId,
+                'space_id' => $this->spaceId,
+                'publish_at' => $release->publish_at,
+            ]);
+
+            if ($release->publish_at?->isFuture()) {
+                PublishScheduledReleaseJob::dispatch(
+                    $this->spaceId,
+                    $this->releaseId,
+                )->delay($release->publish_at);
+            }
+
+            return;
+        }
+
+        $publishAction = app(PublishRelease::class);
+        $publishAction->execute($release, $space, null);
+
+        Log::info('Published scheduled release', [
+            'release_id' => $this->releaseId,
+            'space_id' => $this->spaceId,
+        ]);
+    }
+
+    protected function handleFailure(\Exception $e): void
+    {
+        Log::error('Failed to publish scheduled release', [
+            'release_id' => $this->releaseId,
+            'space_id' => $this->spaceId,
+            'error' => $e->getMessage(),
+            'trace' => $e->getTraceAsString(),
+        ]);
+    }
+
+    public function tags(): array
+    {
+        return [
+            'release-publishing',
+            'space:' . $this->spaceId,
+            'release:' . $this->releaseId,
+        ];
+    }
+}

--- a/tests/Unit/Jobs/Content/PublishScheduledContentJobTest.php
+++ b/tests/Unit/Jobs/Content/PublishScheduledContentJobTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Unit\Jobs\Content;
+
+use App\Jobs\Content\PublishScheduledContentJob;
+use App\Models\Management\Space;
+use App\Models\Space\Content;
+use App\Models\Space\ContentVersion;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PublishScheduledContentJobTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    #[Test]
+    public function itPublishesScheduledContent()
+    {
+        $space = Space::factory()->create();
+        app()->offsetSet('currentSpace', $space);
+
+        $content = Content::factory()->for($space)->create();
+        $version = ContentVersion::factory()
+            ->for($content)
+            ->create([
+                'scheduled_at' => now()->subMinute(),
+                'published_at' => null,
+            ]);
+
+        $job = new PublishScheduledContentJob($space->id, $version->id);
+        $job->handle();
+
+        $version->refresh();
+        $this->assertNotNull($version->published_at);
+        $this->assertEquals($content->id, $version->content_id);
+    }
+
+    #[Test]
+    public function itSkipsIfAlreadyPublished()
+    {
+        Log::spy();
+
+        $space = Space::factory()->create();
+        app()->offsetSet('currentSpace', $space);
+
+        $content = Content::factory()->for($space)->create();
+        $version = ContentVersion::factory()
+            ->for($content)
+            ->create([
+                'scheduled_at' => now()->subMinute(),
+                'published_at' => now(),
+            ]);
+
+        $job = new PublishScheduledContentJob($space->id, $version->id);
+        $job->handle();
+
+        Log::shouldHaveReceived('info')
+            ->withArgs(function ($message) {
+                return str_contains($message, 'already published');
+            })
+            ->once();
+
+        $version->refresh();
+        // published_at should not change
+        $this->assertNotNull($version->published_at);
+    }
+
+    #[Test]
+    public function itSkipsIfSpaceNotFound()
+    {
+        Log::spy();
+
+        $job = new PublishScheduledContentJob('invalid-space-id', 'invalid-version-id');
+        $job->handle();
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(function ($message) {
+                return str_contains($message, 'Space not found');
+            })
+            ->once();
+    }
+
+    #[Test]
+    public function itSkipsIfVersionNotFound()
+    {
+        Log::spy();
+
+        $space = Space::factory()->create();
+
+        $job = new PublishScheduledContentJob($space->id, 'invalid-version-id');
+        $job->handle();
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(function ($message) {
+                return str_contains($message, 'Content version not found');
+            })
+            ->once();
+    }
+
+    #[Test]
+    public function itSkipsIfContentModelNotFound()
+    {
+        Log::spy();
+
+        $space = Space::factory()->create();
+        app()->offsetSet('currentSpace', $space);
+
+        $version = ContentVersion::factory()
+            ->create([
+                'content_id' => 'invalid-content-id',
+                'scheduled_at' => now()->subMinute(),
+                'published_at' => null,
+            ]);
+
+        $job = new PublishScheduledContentJob($space->id, $version->id);
+        $job->handle();
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(function ($message) {
+                return str_contains($message, 'Content model not found');
+            })
+            ->once();
+    }
+
+    #[Test]
+    public function itRequeuesIfScheduleTimeNotYetMet()
+    {
+        $space = Space::factory()->create();
+        app()->offsetSet('currentSpace', $space);
+
+        $content = Content::factory()->for($space)->create();
+        $futureTime = now()->addHours(2);
+        $version = ContentVersion::factory()
+            ->for($content)
+            ->create([
+                'scheduled_at' => $futureTime,
+                'published_at' => null,
+            ]);
+
+        $job = new PublishScheduledContentJob($space->id, $version->id);
+        $job->handle();
+
+        // Verify version was not published
+        $version->refresh();
+        $this->assertNull($version->published_at);
+    }
+
+    #[Test]
+    public function itIncludesTags()
+    {
+        $spaceId = 'space-123';
+        $versionId = 'version-456';
+
+        $job = new PublishScheduledContentJob($spaceId, $versionId);
+
+        $tags = $job->tags();
+        $this->assertContains('content-publishing', $tags);
+        $this->assertContains('space:' . $spaceId, $tags);
+        $this->assertContains('content-version:' . $versionId, $tags);
+    }
+
+    #[Test]
+    public function itHasCorrectTimeout()
+    {
+        $job = new PublishScheduledContentJob('space-id', 'version-id');
+        $this->assertEquals(300, $job->timeout);
+    }
+}

--- a/tests/Unit/Jobs/Release/PublishScheduledReleaseJobTest.php
+++ b/tests/Unit/Jobs/Release/PublishScheduledReleaseJobTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tests\Unit\Jobs\Release;
+
+use App\Jobs\Release\PublishScheduledReleaseJob;
+use App\Models\Management\Space;
+use App\Models\Space\Content;
+use App\Models\Space\ContentVersion;
+use App\Models\Space\Release;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PublishScheduledReleaseJobTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    #[Test]
+    public function itPublishesScheduledRelease()
+    {
+        $space = Space::factory()->create();
+        app()->offsetSet('currentSpace', $space);
+
+        $release = Release::factory()
+            ->for($space)
+            ->create([
+                'publish_at' => now()->subMinute(),
+                'published_at' => null,
+                'committed_at' => now()->subHour(),
+            ]);
+
+        $content = Content::factory()->for($space)->create();
+        $version = ContentVersion::factory()
+            ->for($content)
+            ->for($release)
+            ->create([
+                'published_at' => null,
+            ]);
+
+        $job = new PublishScheduledReleaseJob($space->id, $release->id);
+        $job->handle();
+
+        $release->refresh();
+        $this->assertNotNull($release->published_at);
+
+        $version->refresh();
+        $this->assertNotNull($version->published_at);
+    }
+
+    #[Test]
+    public function itSkipsIfAlreadyPublished()
+    {
+        Log::spy();
+
+        $space = Space::factory()->create();
+        app()->offsetSet('currentSpace', $space);
+
+        $release = Release::factory()
+            ->for($space)
+            ->create([
+                'publish_at' => now()->subMinute(),
+                'published_at' => now(),
+                'committed_at' => now()->subHour(),
+            ]);
+
+        $job = new PublishScheduledReleaseJob($space->id, $release->id);
+        $job->handle();
+
+        Log::shouldHaveReceived('info')
+            ->withArgs(function ($message) {
+                return str_contains($message, 'already published');
+            })
+            ->once();
+
+        $release->refresh();
+        $this->assertNotNull($release->published_at);
+    }
+
+    #[Test]
+    public function itSkipsIfNotCommitted()
+    {
+        Log::spy();
+
+        $space = Space::factory()->create();
+        app()->offsetSet('currentSpace', $space);
+
+        $release = Release::factory()
+            ->for($space)
+            ->create([
+                'publish_at' => now()->subMinute(),
+                'published_at' => null,
+                'committed_at' => null,
+            ]);
+
+        $job = new PublishScheduledReleaseJob($space->id, $release->id);
+        $job->handle();
+
+        Log::shouldHaveReceived('info')
+            ->withArgs(function ($message) {
+                return str_contains($message, 'not yet committed');
+            })
+            ->once();
+
+        $release->refresh();
+        $this->assertNull($release->published_at);
+    }
+
+    #[Test]
+    public function itSkipsIfSpaceNotFound()
+    {
+        Log::spy();
+
+        $job = new PublishScheduledReleaseJob('invalid-space-id', 'invalid-release-id');
+        $job->handle();
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(function ($message) {
+                return str_contains($message, 'Space not found');
+            })
+            ->once();
+    }
+
+    #[Test]
+    public function itSkipsIfReleaseNotFound()
+    {
+        Log::spy();
+
+        $space = Space::factory()->create();
+
+        $job = new PublishScheduledReleaseJob($space->id, 'invalid-release-id');
+        $job->handle();
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(function ($message) {
+                return str_contains($message, 'Release not found');
+            })
+            ->once();
+    }
+
+    #[Test]
+    public function itRequeuesIfPublishTimeNotYetMet()
+    {
+        $space = Space::factory()->create();
+        app()->offsetSet('currentSpace', $space);
+
+        $futureTime = now()->addHours(2);
+        $release = Release::factory()
+            ->for($space)
+            ->create([
+                'publish_at' => $futureTime,
+                'published_at' => null,
+                'committed_at' => now()->subHour(),
+            ]);
+
+        $job = new PublishScheduledReleaseJob($space->id, $release->id);
+        $job->handle();
+
+        $release->refresh();
+        $this->assertNull($release->published_at);
+    }
+
+    #[Test]
+    public function itIncludesTags()
+    {
+        $spaceId = 'space-123';
+        $releaseId = 'release-456';
+
+        $job = new PublishScheduledReleaseJob($spaceId, $releaseId);
+
+        $tags = $job->tags();
+        $this->assertContains('release-publishing', $tags);
+        $this->assertContains('space:' . $spaceId, $tags);
+        $this->assertContains('release:' . $releaseId, $tags);
+    }
+
+    #[Test]
+    public function itHasCorrectTimeout()
+    {
+        $job = new PublishScheduledReleaseJob('space-id', 'release-id');
+        $this->assertEquals(300, $job->timeout);
+    }
+}


### PR DESCRIPTION
## Current Implementation

Space operations (releases and scheduled content versions) are currently handled via scheduled Artisan commands that iterate through every space to check for pending work. This approach is inefficient as it processes all spaces regardless of whether work is needed.

## Proposed Solution

Refactor to use a Laravel database-driven queue system that processes jobs only when needed, based on \`scheduled\_at\` or \`publish\_at\` timestamps.

### Requirements

#### Architecture

- Implement a database-driven queue to handle delayed job execution
- Serialize the space and corresponding model in the job payload
- Set \`app()->offsetSet('currentSpace')\` within the job handler to ensure SpaceModels use the correct database connection
- Verify conditions are still met before executing the job (guard against stale data)

#### Queue Configuration

- Configure Laravel queue to use the \`database\` driver
- \*\*Important:\*\* Document that alternative queue drivers (e.g., SQS) may be unreliable for this use case due to limitations (SQS has a 15-minute maximum delay)
- Set up \`queue:worker\` in Supervisor configuration if not already present

#### Migration Strategy

- Remove existing scheduled commands once the queue solution is validated
- \*\*Fallback Safety:\*\* If immediate removal is risky, replace existing commands with a reduced-frequency check (hourly) that:
- Identifies orphaned releases or scheduled ContentVersions
- Re-queues them for processing
- Acts as a safety net during transition period

### Implementation Guidelines

- Follow existing codebase conventions and best practices
- Apply SOLID principles and Laravel framework best practices
- Write clean, self-documenting code with comments only where complexity requires explanation
- Ensure proper error handling and logging for failed jobs

## Expected Benefits

- Reduced server load by eliminating unnecessary iteration
- More precise execution timing
- Better scalability as space count grows
- Improved observability through Laravel's queue monitoring tools